### PR TITLE
Tests add windows runner

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -1,6 +1,5 @@
 name: "PR Checks"
 on:
-  workflow_dispatch:
   pull_request:
     branches: "*"
   push:

--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -41,7 +41,7 @@ jobs:
           credentials: |
             https://user:password@example.com
             https://user:password@example.org
-      - run: diff ${XDG_CONFIG_HOME:-$HOME/.config}/git/credentials tests/start-empty.expected
+      - run: diff --strip-trailing-cr ${XDG_CONFIG_HOME:-$HOME/.config}/git/credentials tests/start-empty.expected
   test-start-empty:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -27,6 +27,9 @@ jobs:
             && exit 1)
   test-new-file:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -1,5 +1,6 @@
 name: "PR Checks"
 on:
+  workflow_dispatch:
   pull_request:
     branches: "*"
   push:

--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -25,7 +25,10 @@ jobs:
                  "and check in all changes" \
             && exit 1)
   test-new-file:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - run: rm -f ${XDG_CONFIG_HOME:-$HOME/.config}/git/credentials


### PR DESCRIPTION
This PR adds a windows-latest runner to a single test in the checkin.yml workflow.

The windows runner default shell (powershell) is overriden by specifying
defaults: run: shell: bash
(this could be done more simply by following the single run: command with a shell: bash line)

The diff command gave a bogus diff on windows, probably because of the different line endings -
adding --strip-trailing-cr fixed it

This single test provides a sanity check on windows.
Following this pattern, a windows runner could be added to the remaining tests.
Don't know if that's worth it.